### PR TITLE
Phase 2: Knowledge Store — persist to brain + Basic Memory setup

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -16,7 +16,7 @@ Fork of `assafelovic/gpt-researcher` adapted into a personal research → knowle
                        └────────┬─────────┘
                                 │  synthesized markdown + sources
                                 ▼
-                   ~/brain/research/*.md      ◀── Basic Memory MCP
+                   ~/basic-memory/research/*.md      ◀── Basic Memory MCP
                                 │                  (queryable via Claude)
                                 ▼
                      ┌─────────────────────┐
@@ -57,25 +57,32 @@ Shipped as PR #4, squashed into `main` at `f30db1ed`. Closed issues #1, #2, #3.
 
 ---
 
-## Phase 2 — Knowledge Store
+## Phase 2 — Knowledge Store (code DONE; user setup pending)
 
 **Goal:** Every research output persists to a queryable second brain.
 
-**Tasks:**
-- Install Basic Memory — `uv tool install basic-memory` or `pip install basic-memory`
-- Point it at `~/brain/` (its default)
-- Add post-research hook in the fork — after `write_report()` completes, write to `~/brain/research/{YYYY-MM-DD}-{slug}.md` with YAML frontmatter (topic, sources, date, status: `draft_ready`)
-- Connect Basic Memory's MCP server to Claude Desktop — `basic-memory mcp`
-- Verify — ask Claude "what have I researched about X?" and get a real answer from the vault
+**Code shipped (this PR):**
+- `brain/` package writes every CLI research run to `~/basic-memory/research/{YYYY-MM-DD}-{slug}.md` with YAML frontmatter (topic, date, sources, source_count, config snapshot).
+- `BRAIN_PATH` env var overrides the default. Default `~/basic-memory/` aligns with Basic Memory's convention so no extra config is needed.
+- Brain save is non-fatal — a failed write prints a warning but doesn't break the CLI.
+
+**User machine setup (your part):**
+Follow `docs/BASIC_MEMORY_SETUP.md`:
+1. `uv tool install basic-memory`
+2. `basic-memory sync --watch &`
+3. Edit `~/Library/Application Support/Claude/claude_desktop_config.json` to register the MCP server
+4. Restart Claude Desktop
+5. Ask Claude: "What have I researched about X?"
 
 **Exit criteria:**
-- [ ] Research auto-stores to `~/brain/research/`
-- [ ] Claude Desktop can search + cite notes from the vault
-- [ ] Frontmatter includes sources so you can trace back
+- [x] Research auto-stores to `~/basic-memory/research/`
+- [ ] Claude Desktop can search + cite notes from the vault *(user setup step)*
+- [x] Frontmatter includes sources so you can trace back
 
 **Notes:**
-- Plain markdown on disk — you can grep, open in any editor, move anywhere
+- Plain markdown on disk — grep, open in any editor, move anywhere
 - Basic Memory rebuilds its index from source files anytime (zero lock-in)
+- The brain is *indexer-agnostic* — works with Obsidian, Logseq, etc. too
 
 ---
 
@@ -177,7 +184,7 @@ Shipped as PR #4, squashed into `main` at `f30db1ed`. Closed issues #1, #2, #3.
   - Generate 3–5 personas per topic (expert, contrarian, novice, practitioner)
   - Simulate writer↔expert turns grounded in retrieved sources
   - Feed transcript into final draft
-- Voice-locking — few-shot layer using your best past posts as style exemplars (store in `~/brain/voice/`)
+- Voice-locking — few-shot layer using your best past posts as style exemplars (store in `~/basic-memory/voice/`)
 - Regenerate-with-notes — text box for critique, second-pass rewrite incorporating feedback
 - Prompt evals — pytest suite that runs known topics through the pipeline, scores output against `docs/baseline/` (Phase 1 baseline is the first reference point)
 

--- a/brain/__init__.py
+++ b/brain/__init__.py
@@ -1,9 +1,10 @@
 """content-brain local persistence layer.
 
 This package writes research reports to a personal knowledge directory
-(defaults to ~/brain/). It is intentionally decoupled from any specific
-indexer — the output is plain markdown on disk, readable by Basic Memory,
-Obsidian, Logseq, or plain filesystem tools.
+(defaults to `~/basic-memory/` to align with Basic Memory's convention).
+It is intentionally decoupled from any specific indexer — the output is
+plain markdown on disk, readable by Basic Memory, Obsidian, Logseq, or
+plain filesystem tools.
 """
 
 from .writer import save_research

--- a/brain/__init__.py
+++ b/brain/__init__.py
@@ -1,0 +1,11 @@
+"""content-brain local persistence layer.
+
+This package writes research reports to a personal knowledge directory
+(defaults to ~/brain/). It is intentionally decoupled from any specific
+indexer — the output is plain markdown on disk, readable by Basic Memory,
+Obsidian, Logseq, or plain filesystem tools.
+"""
+
+from .writer import save_research
+
+__all__ = ["save_research"]

--- a/brain/writer.py
+++ b/brain/writer.py
@@ -1,0 +1,72 @@
+"""Persist research reports to a personal knowledge base on disk."""
+
+from __future__ import annotations
+
+import os
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+
+DEFAULT_BRAIN_PATH = "~/brain"
+
+
+def save_research(
+    report_markdown: str,
+    topic: str,
+    sources: Iterable[str] = (),
+    config: dict | None = None,
+) -> Path:
+    """Save a research report to the brain as a dated, slugged markdown file.
+
+    The file is written to `{BRAIN_PATH}/research/{YYYY-MM-DD}-{slug}.md` with
+    YAML frontmatter capturing topic, date, source URLs, source count, and
+    (optionally) a config snapshot. The brain path is configurable via the
+    `BRAIN_PATH` environment variable and defaults to `~/brain`.
+
+    Returns the absolute path of the written file.
+    """
+    root = _brain_root() / "research"
+    root.mkdir(parents=True, exist_ok=True)
+
+    date_str = datetime.now().strftime("%Y-%m-%d")
+    slug = _slugify(topic) or "untitled"
+    path = _unique_path(root, date_str, slug)
+
+    unique_sources = list(dict.fromkeys(s for s in sources if s))
+    frontmatter_fields: dict = {
+        "topic": topic,
+        "date": date_str,
+        "source_count": len(unique_sources),
+        "sources": unique_sources,
+        "status": "draft_ready",
+    }
+    if config:
+        frontmatter_fields["config"] = config
+
+    frontmatter = "---\n" + yaml.safe_dump(
+        frontmatter_fields, sort_keys=False, default_flow_style=False
+    ) + "---"
+    path.write_text(f"{frontmatter}\n{report_markdown}\n", encoding="utf-8")
+    return path
+
+
+def _brain_root() -> Path:
+    return Path(os.getenv("BRAIN_PATH", DEFAULT_BRAIN_PATH)).expanduser()
+
+
+def _slugify(text: str, max_len: int = 60) -> str:
+    slug = re.sub(r"[^\w\s-]", "", text.lower()).strip()
+    slug = re.sub(r"[\s_-]+", "-", slug)
+    return slug[:max_len].rstrip("-")
+
+
+def _unique_path(root: Path, date_str: str, slug: str) -> Path:
+    candidate = root / f"{date_str}-{slug}.md"
+    counter = 2
+    while candidate.exists():
+        candidate = root / f"{date_str}-{slug}-{counter}.md"
+        counter += 1
+    return candidate

--- a/brain/writer.py
+++ b/brain/writer.py
@@ -10,7 +10,7 @@ from typing import Iterable
 
 import yaml
 
-DEFAULT_BRAIN_PATH = "~/brain"
+DEFAULT_BRAIN_PATH = "~/basic-memory"
 
 
 def save_research(
@@ -24,7 +24,8 @@ def save_research(
     The file is written to `{BRAIN_PATH}/research/{YYYY-MM-DD}-{slug}.md` with
     YAML frontmatter capturing topic, date, source URLs, source count, and
     (optionally) a config snapshot. The brain path is configurable via the
-    `BRAIN_PATH` environment variable and defaults to `~/brain`.
+    `BRAIN_PATH` environment variable and defaults to `~/basic-memory` (the
+    Basic Memory convention — swap to any directory you like).
 
     Returns the absolute path of the written file.
     """

--- a/cli.py
+++ b/cli.py
@@ -20,6 +20,7 @@ from gpt_researcher import GPTResearcher
 from gpt_researcher.utils.enum import ReportType, ReportSource, Tone
 from backend.report_type import DetailedReport
 from backend.utils import write_md_to_pdf, write_md_to_word
+from brain import save_research
 
 # =============================================================================
 # CLI
@@ -191,6 +192,38 @@ async def main(args):
     with open(artifact_filepath, "w", encoding="utf-8") as f:
         f.write(report)
     print(f"Report written to '{artifact_filepath}'")
+
+    # Persist to the brain for later search / publishing / chat.
+    # DetailedReport doesn't expose research_sources, so sources are empty
+    # there; single-pass reports pull them from the researcher instance.
+    # We use research_sources (not visited_urls) because it includes both
+    # scraped URLs and retriever-prefetched URLs (e.g. Tavily snippets).
+    try:
+        sources: list[str] = []
+        if args.report_type != 'detailed_report':
+            sources = sorted({
+                s.get("url") or s.get("href")
+                for s in researcher.get_research_sources()
+                if s.get("url") or s.get("href")
+            })
+        brain_path = save_research(
+            report_markdown=report,
+            topic=args.query,
+            sources=sources,
+            config={
+                "smart_llm": os.getenv("SMART_LLM", ""),
+                "fast_llm": os.getenv("FAST_LLM", ""),
+                "strategic_llm": os.getenv("STRATEGIC_LLM", ""),
+                "embedding": os.getenv("EMBEDDING", ""),
+                "retriever": os.getenv("RETRIEVER", ""),
+                "report_type": args.report_type,
+                "tone": args.tone,
+            },
+        )
+        print(f"Saved to brain: {brain_path}")
+    except Exception as e:
+        # Brain save is non-fatal — CLI should still finish successfully.
+        print(f"Warning: brain save failed: {e}")
 
     # Generate PDF if not disabled
     if not args.no_pdf:

--- a/docs/BASIC_MEMORY_SETUP.md
+++ b/docs/BASIC_MEMORY_SETUP.md
@@ -1,0 +1,140 @@
+# Basic Memory + Claude Desktop Setup
+
+This guide wires [Basic Memory](https://github.com/basicmachines-co/basic-memory) onto the directory that `content-brain` writes research reports to, then exposes it as an MCP server to Claude Desktop so you can query your brain in chat.
+
+**Prerequisite:** Phase 2 code is merged (the CLI writes to `~/basic-memory/research/` after each research run).
+
+**Not dependent on Basic Memory.** The brain is just markdown on disk. Basic Memory is one possible indexer. You can substitute Obsidian, Logseq, or plain grep — the CLI doesn't care.
+
+---
+
+## 1. Install Basic Memory
+
+Recommended (uv-managed tool install, auto-isolated):
+
+```bash
+uv tool install basic-memory
+```
+
+Verify:
+
+```bash
+basic-memory --version
+```
+
+> If you don't have `uv`: `brew install uv` on macOS or `curl -LsSf https://astral.sh/uv/install.sh | sh`.
+
+## 2. Confirm the Vault Path
+
+Basic Memory's default vault is `~/basic-memory/`, which matches `content-brain`'s default `BRAIN_PATH`. Verify the directory exists and has your research:
+
+```bash
+ls ~/basic-memory/research/
+```
+
+You should see one markdown file per research run, e.g. `2026-04-19-fastapi-dependency-injection-patterns.md`.
+
+If you want the brain somewhere else, set `BRAIN_PATH` in `.env` and point Basic Memory at the same path via a named project (see §7).
+
+## 3. Initial Sync
+
+Index every markdown file currently in the vault:
+
+```bash
+basic-memory sync
+```
+
+Then run it in watch mode (keeps the index current as new research lands):
+
+```bash
+basic-memory sync --watch &
+```
+
+(Or run it in a terminal tab / `tmux` / `launchd` — up to you.)
+
+## 4. Wire the MCP Server Into Claude Desktop
+
+Edit (or create) the Claude Desktop config:
+
+```bash
+~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+Add the `basic-memory` entry under `mcpServers`:
+
+```json
+{
+  "mcpServers": {
+    "basic-memory": {
+      "command": "uvx",
+      "args": ["basic-memory", "mcp"]
+    }
+  }
+}
+```
+
+If you already have other MCP servers configured, merge — don't overwrite.
+
+**Restart Claude Desktop.** The MCP connection is established at app startup, not on the fly.
+
+## 5. Verify in Chat
+
+Open Claude Desktop and try:
+
+> What research notes do I have about FastAPI dependency injection?
+
+Claude should call Basic Memory tools, cite the file, and quote content. If it says it has no access, the MCP server isn't connected — check the config JSON for typos and restart the app.
+
+Useful verification prompts:
+
+- `"Find notes about <topic I researched>"`
+- `"Summarize the last 3 research reports"`
+- `"What sources did I cite in the <slug> note?"`
+
+## 6. Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| Claude says "no MCP tools available" | Restart Claude Desktop after editing the config. |
+| `uvx: command not found` in Claude logs | Install `uv` (see §1). Claude Desktop inherits your shell PATH only if launched from terminal; otherwise you may need to use an absolute path like `/opt/homebrew/bin/uvx` in the config. |
+| Notes don't appear in search | `basic-memory sync` once, confirm files are indexed, then check `basic-memory doctor`. |
+| Watch mode stops after reboot | Move it under `launchd` or a process supervisor. Not scripted here — manual for now. |
+
+## 7. Optional: Custom Vault Path
+
+If you don't want `~/basic-memory/`, set your own:
+
+```bash
+# .env (content-brain)
+BRAIN_PATH=~/work/notes
+```
+
+Then create a named Basic Memory project pointing there:
+
+```bash
+basic-memory project create my-brain ~/work/notes
+basic-memory project set-local my-brain
+```
+
+And update the MCP config to target it:
+
+```json
+{
+  "mcpServers": {
+    "basic-memory": {
+      "command": "uvx",
+      "args": ["basic-memory", "mcp", "--project", "my-brain"]
+    }
+  }
+}
+```
+
+## 8. What You've Built
+
+You now have:
+
+1. **A growing research archive** — every CLI run auto-saves to `~/basic-memory/research/` with frontmatter (topic, date, source URLs, source count, config snapshot).
+2. **Semantic search over that archive** via Basic Memory.
+3. **Chat-with-your-brain** via Claude Desktop — no custom UI needed.
+
+This satisfies Phase 2's exit criteria. Phase 3 (approval queue) can now read and write to the same brain.


### PR DESCRIPTION
## Summary

Phase 2 Knowledge Store. Every CLI research run now auto-saves to `~/basic-memory/research/{YYYY-MM-DD}-{slug}.md` with YAML frontmatter. Code side is DONE; user setup (Basic Memory install + Claude Desktop MCP wiring) is documented.

### Code
- New `brain/` package with `save_research()` (~70 lines, pure stdlib + pyyaml)
- `cli.py` hooks into the post-report path, pulling sources from `researcher.get_research_sources()` (captures both scraped and retriever-prefetched URLs)
- Default path `~/basic-memory/` matches Basic Memory's convention so zero config is needed
- `BRAIN_PATH` env var overrides

### Docs
- `docs/BASIC_MEMORY_SETUP.md` — full install → sync → Claude Desktop MCP flow, with troubleshooting
- `PLAN.md` Phase 2 updated: code DONE, user setup pending; path references aligned

## Test Plan

- [x] End-to-end CLI run writes to `~/basic-memory/research/` (verified: "FastAPI dependency injection patterns" → 18 real sources, clean frontmatter)
- [x] `BRAIN_PATH` override tested (via `/tmp/brain-test` during dev)
- [x] Brain save is non-fatal — CLI still finishes if the write errors
- [x] Imports clean, syntax valid

## Phase 2 Exit

- [x] Research auto-stores — code side
- [ ] Claude Desktop queries brain — user setup step (docs in place)
- [x] Frontmatter traceability

Closes #6
Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)