### PR TITLE
feat(brain): auto-reindex Basic Memory after each research save

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,13 @@ TAVILY_API_KEY=
 XQUIK_API_KEY=
 DOC_PATH=./my-docs
 
+# content-brain knowledge store (Phase 2)
+# BRAIN_PATH defaults to ~/basic-memory so it works out of the box with
+# Basic Memory's default project location. Override if you store notes
+# elsewhere. BRAIN_AUTOINDEX=0 disables the post-save reindex.
+#BRAIN_PATH=~/basic-memory
+#BRAIN_AUTOINDEX=1
+
 # NEXT_PUBLIC_GPTR_API_URL=http://0.0.0.0:8000  # Defaults to localhost:8000 if not set
 
 # Scraper Configuration

--- a/brain/writer.py
+++ b/brain/writer.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import os
 import re
+import shutil
+import subprocess
 from datetime import datetime
 from pathlib import Path
 from typing import Iterable
@@ -11,6 +13,7 @@ from typing import Iterable
 import yaml
 
 DEFAULT_BRAIN_PATH = "~/basic-memory"
+REINDEX_TIMEOUT_SECONDS = 60
 
 
 def save_research(
@@ -18,6 +21,8 @@ def save_research(
     topic: str,
     sources: Iterable[str] = (),
     config: dict | None = None,
+    *,
+    reindex: bool = True,
 ) -> Path:
     """Save a research report to the brain as a dated, slugged markdown file.
 
@@ -26,6 +31,11 @@ def save_research(
     (optionally) a config snapshot. The brain path is configurable via the
     `BRAIN_PATH` environment variable and defaults to `~/basic-memory` (the
     Basic Memory convention — swap to any directory you like).
+
+    When `reindex=True` (the default) and `basic-memory` is on PATH, the
+    function triggers a reindex so the new note is queryable immediately
+    from Claude Desktop via the Basic Memory MCP. Set the env var
+    `BRAIN_AUTOINDEX=0` to disable reindex globally.
 
     Returns the absolute path of the written file.
     """
@@ -51,6 +61,10 @@ def save_research(
         frontmatter_fields, sort_keys=False, default_flow_style=False
     ) + "---"
     path.write_text(f"{frontmatter}\n{report_markdown}\n", encoding="utf-8")
+
+    if reindex and os.getenv("BRAIN_AUTOINDEX", "1") != "0":
+        _reindex_brain()
+
     return path
 
 
@@ -71,3 +85,25 @@ def _unique_path(root: Path, date_str: str, slug: str) -> Path:
         candidate = root / f"{date_str}-{slug}-{counter}.md"
         counter += 1
     return candidate
+
+
+def _reindex_brain() -> None:
+    """Trigger `basic-memory reindex` so new notes are searchable.
+
+    Silent no-op if `basic-memory` isn't installed. Failures are swallowed
+    intentionally — the markdown file is already on disk; a failed reindex
+    just means the note won't surface in Claude Desktop until the next
+    successful index.
+    """
+    bm = shutil.which("basic-memory")
+    if not bm:
+        return
+    try:
+        subprocess.run(
+            [bm, "reindex"],
+            check=False,
+            capture_output=True,
+            timeout=REINDEX_TIMEOUT_SECONDS,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        pass

--- a/docs/BASIC_MEMORY_SETUP.md
+++ b/docs/BASIC_MEMORY_SETUP.md
@@ -36,21 +36,19 @@ You should see one markdown file per research run, e.g. `2026-04-19-fastapi-depe
 
 If you want the brain somewhere else, set `BRAIN_PATH` in `.env` and point Basic Memory at the same path via a named project (see §7).
 
-## 3. Initial Sync
+## 3. Create the Project + Initial Index
 
-Index every markdown file currently in the vault:
-
-```bash
-basic-memory sync
-```
-
-Then run it in watch mode (keeps the index current as new research lands):
+Basic Memory 0.20+ uses named projects. Register `~/basic-memory/` as the default project and build the search index:
 
 ```bash
-basic-memory sync --watch &
+basic-memory project add main ~/basic-memory
+basic-memory project default main
+echo "y" | basic-memory reset --reindex
 ```
 
-(Or run it in a terminal tab / `tmux` / `launchd` — up to you.)
+The `reset --reindex` step drops any stale index state and rebuilds from the markdown files on disk. It also downloads the `bge-small-en-v1.5` embedding model on first run (~90 MB, local, free).
+
+**Ongoing updates happen automatically.** Every CLI research run calls `basic-memory reindex` after writing the new note, so Claude Desktop sees it immediately. To disable this behavior, set `BRAIN_AUTOINDEX=0` in your environment.
 
 ## 4. Wire the MCP Server Into Claude Desktop
 
@@ -97,7 +95,8 @@ Useful verification prompts:
 |---|---|
 | Claude says "no MCP tools available" | Restart Claude Desktop after editing the config. |
 | `uvx: command not found` in Claude logs | Install `uv` (see §1). Claude Desktop inherits your shell PATH only if launched from terminal; otherwise you may need to use an absolute path like `/opt/homebrew/bin/uvx` in the config. |
-| Notes don't appear in search | `basic-memory sync` once, confirm files are indexed, then check `basic-memory doctor`. |
+| Notes don't appear in search | Run `basic-memory reindex` (or `basic-memory reset --reindex` if the DB feels stale), then check `basic-memory doctor`. |
+| Auto-reindex seems to hang | Set `BRAIN_AUTOINDEX=0` in `.env` and reindex manually on your own cadence. |
 | Watch mode stops after reboot | Move it under `launchd` or a process supervisor. Not scripted here — manual for now. |
 
 ## 7. Optional: Custom Vault Path
@@ -112,8 +111,8 @@ BRAIN_PATH=~/work/notes
 Then create a named Basic Memory project pointing there:
 
 ```bash
-basic-memory project create my-brain ~/work/notes
-basic-memory project set-local my-brain
+basic-memory project add my-brain ~/work/notes
+basic-memory project default my-brain
 ```
 
 And update the MCP config to target it:


### PR DESCRIPTION
## Summary

Close the gap Basic Memory 0.20+ introduced by retiring `sync --watch`: call `basic-memory reindex` inside `save_research()` so new notes are queryable in Claude Desktop immediately after a CLI run — no manual step.

## Design

- **Silent no-op** when `basic-memory` isn't on PATH — the writer stays decoupled from Basic Memory specifically; other indexers (Obsidian, grep) still work against the vault.
- **Non-fatal** — the markdown is already on disk; reindex failures don't propagate.
- **Opt-out** via `BRAIN_AUTOINDEX=0` env var or `reindex=False` kwarg.
- **60 s timeout** guards against unexpected hangs.

## Doc fixes

`docs/BASIC_MEMORY_SETUP.md` still referenced `basic-memory sync` and `sync --watch`, both removed in 0.20+. Replaced with the current `project add / default / reset --reindex` flow.

## Test Plan

- [x] Direct call to `save_research()` with dummy content — Basic Memory entity count went 1 → 2, chunk count 29 → 30 after save. Reindex confirmed to run automatically.
- [x] Syntax + import clean.
- [x] No change to CLI UX beyond "new notes searchable immediately."